### PR TITLE
Re-Add MacOS support

### DIFF
--- a/classes/mcPy/McPy.py
+++ b/classes/mcPy/McPy.py
@@ -2,20 +2,14 @@ import logging
 import multiprocessing
 import os
 import sys
+import psutil
 
 from .Parser import Parser
 import classes.Server as Server
 
 
 def get_available_core():
-    try:
-        avail_cores = len(os.sched_getaffinity(0))
-    except AttributeError:
-        # Fix for windows, which doesnt support getaffinity
-        logging.warning(
-            "Falling back to multiprocessing cpu_count to calc cores. Most likely getaffinity is not supported on "
-            "your OS")
-        avail_cores = multiprocessing.cpu_count()
+    avail_cores = psutil.cpu_count()
     return avail_cores
 
 

--- a/classes/mcPy/MultiProcessing.py
+++ b/classes/mcPy/MultiProcessing.py
@@ -15,7 +15,7 @@ class MultiProcessing():
         self.worker_number = worker_number
         self.max_size = max_size
         self.started = True
-        self.TASK_LIST = multiprocessing.Queue(maxsize=max_size)
+        self.TASK_LIST = multiprocessing.Queue()
         self.workers = []
         for i in range(self.worker_number):
             func_args = (self.TASK_LIST,)

--- a/classes/network/Connection.py
+++ b/classes/network/Connection.py
@@ -57,7 +57,7 @@ class PlayerNetwork(server.ServerProtocol):
         self._protocol_input = self.factory._protocol_input[str(self.protocol_version)]
         self.version = Version.get_version(self.protocol_version)
 
-        self.TASK_QUEUE = multiprocessing.Queue(QUEUE_SIZE)
+        self.TASK_QUEUE = multiprocessing.Queue()
         self._handle_loop = self.ticker.add_loop(1, self.handle_loop)
         # Keep alive loop
         self.ticker.add_loop(20, self._update_keep_alive)
@@ -243,9 +243,9 @@ class ServerFactory(server.ServerFactory):
 
 class NetworkController:
     # Outgoing data (Server => Clients)
-    OUT_QUEUE = multiprocessing.Queue(QUEUE_SIZE)
+    OUT_QUEUE = multiprocessing.Queue()
     # Incoming data (Clients => Server)
-    IN_QUEUE = multiprocessing.Queue(QUEUE_SIZE)
+    IN_QUEUE = multiprocessing.Queue()
     # The Network Process
     networking_process: multiprocessing.Process
 

--- a/classes/network/Connection.py
+++ b/classes/network/Connection.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import threading
+import platform
 
 from multiprocessing.queues import Empty
 
@@ -16,9 +17,10 @@ from .IncomingPacketAction import ServerAction, ServerActionType
 from .PacketType import BasicNetwork, PacketType, PacketTypeInput
 from .versions.v578 import v1_15_2, v1_15_2_Input
 
-
-QUEUE_SIZE = 100000
-
+if (platform.system()== 'Darwin'):
+    QUEUE_SIZE = 32767
+else:
+    QUEUE_SIZE = 100000
 
 class PlayerNetwork(server.ServerProtocol):
 

--- a/classes/network/Connection.py
+++ b/classes/network/Connection.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 import threading
-import platform
 
 from multiprocessing.queues import Empty
 
@@ -17,10 +16,6 @@ from .IncomingPacketAction import ServerAction, ServerActionType
 from .PacketType import BasicNetwork, PacketType, PacketTypeInput
 from .versions.v578 import v1_15_2, v1_15_2_Input
 
-if (platform.system()== 'Darwin'):
-    QUEUE_SIZE = 32767
-else:
-    QUEUE_SIZE = 100000
 
 class PlayerNetwork(server.ServerProtocol):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 quarry
 twisted
-cryptography
+cryptography==3.2
 requests
 pytest
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 quarry
 twisted
-cryptography==3.2
+cryptography>=3.2
 requests
 pytest
 psutil


### PR DESCRIPTION
Resolves #52 

Removes unsupported arguments from `multiprocessing.Queue()`.

Changed utility for finding available threads to `psutil`. This was recommend by @ntoskrnl4 and could be useful later in the project.

Added `psutil` to requirements.txt and bumped `cryptography` version to 3.2 or higher, since the SSL package requires it to be 3.2 or higher.

**Note**: there is still one issue relating to leaked semaphore objects in `multiprocessing.resource_tacker` that needs to be patched.