### PR TITLE
Remove [BUG] and [FEATURE] prefixes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG REPORT]"
+title: ""
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE]"
+title: ""
 labels: enhancement
 assignees: ''
 


### PR DESCRIPTION
I noticed that @ntoskrnl4 removes these tags every time there is a bug report or feature request, so we should probably just change it so that they don't automagically get added.