### PR TITLE
Do not complain about the git install for arbitary reasons

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -35,7 +35,10 @@ try:
     subprocess.check_call(['git', 'submodule', 'init'])
     subprocess.check_call(['git', 'submodule', 'update'])
     logging.info("Dependencies installed")
-except subprocess.CalledProcessError:
+except subprocess.CalledProcessError as e:
+    if (e.returncode == 127):
+        logging.fatal("Git is not installed! Please install it!")
+except FileNotFoundError:
     logging.fatal("Git is not installed! Please install it!")
 
 # Finishing up

--- a/dependencies.py
+++ b/dependencies.py
@@ -40,6 +40,7 @@ except subprocess.CalledProcessError as e:
         logging.fatal("Git is not installed! Please install it!")
 except FileNotFoundError:
     logging.fatal("Git is not installed! Please install it!")
+    sys.exit(-1)
 
 # Finishing up
 with open('releases.json', 'r') as f:


### PR DESCRIPTION
Sometimes git can also return non-0 return codes, for example if a
submodule has already changes within it which would otherwise result in
a overwrite.
The common return code for commands that are not found is
127, however of course this needs further testing whether this also
applies in other execution environment (It is likely so, but god knows
if I am right).