### PR TITLE
Revert "Fix MacOS formatting Error (part 2 ?)"

### DIFF
--- a/classes/mcPy/McPy.py
+++ b/classes/mcPy/McPy.py
@@ -65,4 +65,9 @@ def _launch(parser: Parser):
 def main():
     parser = Parser()
 
+    if parser.debug:
+        logging.info('Debug mode enabled. Don\'t forget to remove debug flag for maximum performance !')
+    logging_level = logging.DEBUG if parser.debug else logging.INFO
+    logging.basicConfig(level=logging_level, format=parser.format, force=True)
+
     _launch(parser)

--- a/classes/mcPy/Parser.py
+++ b/classes/mcPy/Parser.py
@@ -9,11 +9,19 @@ class Parser:
         self.parse_arguments()
 
     def initialize_arguments(self):
-
+        self.parser.add_argument("--debug",              # Command line flag to set logging in DEBUG mode
+                                 action="store_true",    # Syntactic sugar to say 'default:"false"'
+                                 help="Set logging to DEBUG level")
         self.parser.add_argument("--test",               # Only launch tests
                                  action="store_true",    # Syntactic sugar to say 'default:"false"'
                                  help="Do not launch the server, only launch tests")
+        self.parser.add_argument("--format",             # Command line flag to set the log format
+                                 nargs='?',              # We expect another argument after that
+                                 default="[%(asctime)s - %(levelname)s - %(threadName)s] %(message)s",
+                                 help="Set the logging format to the specified format. (Default: \"%(default)s\")")
 
     def parse_arguments(self):
         self.args = self.parser.parse_args()
+        self.debug = self.args.debug
         self.test = self.args.test
+        self.format = self.args.format

--- a/main.py
+++ b/main.py
@@ -13,7 +13,5 @@ if sys.version_info < (3, 8):
 
 import classes
 
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s - %(levelname)s - %(threadName)s] %(message)s', force=True)
-
 if __name__ == "__main__":
     classes.mcPy.main()


### PR DESCRIPTION
Reverts #73

Removing the debug flag seems to be pointless and controversial. Lets just drop macOS support and restore the flag.

